### PR TITLE
Adding the seed Data Menu Items

### DIFF
--- a/app/interfaces/menu-item.ts
+++ b/app/interfaces/menu-item.ts
@@ -1,0 +1,5 @@
+export interface MenuItem {
+    url: string;
+    title: string;
+    isActive?: boolean;
+  }

--- a/app/seed/menu-data.ts
+++ b/app/seed/menu-data.ts
@@ -1,0 +1,10 @@
+import { MenuItem } from "~/interfaces/menu-item";
+
+export const menuData: MenuItem[] = [
+        { url: '/people', title: 'People', isActive: false }, 
+        { url: '/planets', title: 'Planets', isActive: false},
+        { url: '/films', title: 'Films', isActive: false},
+        { url: '/species', title: 'Species', isActive: false},
+        { url: '/vehicles', title: 'Vehicles', isActive: false},
+        { url: '/starships', title: 'Starships', isActive: false}
+    ];


### PR DESCRIPTION
# Adding The Seed Data Menu Items

## Description of change

Add the menu items to be used to create the sidebar and navbar

## Issue

The SideBar and NavBar need the data to load their respective menu. 

## Solution 

It was created a typescript interface called menu-item and menu-data typescript that uses the interface to create a constant variable called menuData and exported it.

## Modified Files

- `app/interfaces/menu-item.ts`
- `app/seed/menu-data.ts`
