### PR TITLE
Feature/sidebar menu

### DIFF
--- a/app/components/shared/sidebar/SidebarHeader.tsx
+++ b/app/components/shared/sidebar/SidebarHeader.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+
+export const SidebarHeader = () => {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded border p-4">
+      <div className="avatar h-8 w-8 rounded-full bg-emerald-500"></div>
+      <div className="">
+        <p className="text-[16px] font-bold">Star Wars Challenge</p>
+        <p>Interviews</p>
+      </div>
+    </div>
+  );
+};

--- a/app/components/shared/sidebar/SidebarMenu.tsx
+++ b/app/components/shared/sidebar/SidebarMenu.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { SidebarHeader } from "./SidebarHeader";
+import { Plane } from "lucide-react";
 import {
   Command,
   CommandGroup,
@@ -18,11 +19,12 @@ export const SidebarMenu = () => {
           <CommandList>
             <CommandGroup heading="Applications">
               {menuData.map((data) => (
-                <CommandItem key={data.url} className="flex gap-2">
-                  <Link to={data.url}>
-                    <span>{data.title}</span>
-                  </Link>
-                </CommandItem>
+                <Link to={data.url}>
+                  <CommandItem key={data.url} className="flex gap-2">
+                    <Plane />
+                    {data.title}
+                  </CommandItem>
+                </Link>
               ))}
             </CommandGroup>
           </CommandList>

--- a/app/components/shared/sidebar/SidebarMenu.tsx
+++ b/app/components/shared/sidebar/SidebarMenu.tsx
@@ -1,11 +1,35 @@
 import React from "react";
 import { SidebarHeader } from "./SidebarHeader";
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command";
+import { menuData } from "~/seed";
+import { redirect } from "@remix-run/node";
 
 export const SidebarMenu = () => {
   return (
     <div className="min-h-screen w-[300px] min-w-[300px] border-r p-4">
       <SidebarHeader />
-      SidebarMenu
+      <div className="grow">
+        <Command>
+          <CommandList>
+            <CommandGroup heading="Applications">
+              {menuData.map((data) => (
+                <CommandItem
+                  key={data.url}
+                  className="flex gap-2"
+                  onClick={() => redirect(data.url)}
+                >
+                  <span>{data.title}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </div>
     </div>
   );
 };

--- a/app/components/shared/sidebar/SidebarMenu.tsx
+++ b/app/components/shared/sidebar/SidebarMenu.tsx
@@ -7,7 +7,7 @@ import {
   CommandList,
 } from "~/components/ui/command";
 import { menuData } from "~/seed";
-import { redirect } from "@remix-run/node";
+import { Link } from "@remix-run/react";
 
 export const SidebarMenu = () => {
   return (
@@ -18,12 +18,10 @@ export const SidebarMenu = () => {
           <CommandList>
             <CommandGroup heading="Applications">
               {menuData.map((data) => (
-                <CommandItem
-                  key={data.url}
-                  className="flex gap-2"
-                  onClick={() => redirect(data.url)}
-                >
-                  <span>{data.title}</span>
+                <CommandItem key={data.url} className="flex gap-2">
+                  <Link to={data.url}>
+                    <span>{data.title}</span>
+                  </Link>
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/app/components/shared/sidebar/SidebarMenu.tsx
+++ b/app/components/shared/sidebar/SidebarMenu.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { SidebarHeader } from "./SidebarHeader";
+
+export const SidebarMenu = () => {
+  return (
+    <div className="min-h-screen w-[300px] min-w-[300px] border-r p-4">
+      <SidebarHeader />
+      SidebarMenu
+    </div>
+  );
+};

--- a/app/components/shared/sidebar/SidebarMenu.tsx
+++ b/app/components/shared/sidebar/SidebarMenu.tsx
@@ -3,6 +3,7 @@ import { SidebarHeader } from "./SidebarHeader";
 import { Plane } from "lucide-react";
 import {
   Command,
+  CommandEmpty,
   CommandGroup,
   CommandItem,
   CommandList,
@@ -14,13 +15,17 @@ export const SidebarMenu = () => {
   return (
     <div className="min-h-screen w-[300px] min-w-[300px] border-r p-4">
       <SidebarHeader />
-      <div className="grow">
-        <Command>
+      <div className="my-5 ">
+        <Command className="rounded-lg border">
           <CommandList>
+            <CommandEmpty>No results found.</CommandEmpty>
             <CommandGroup heading="Applications">
               {menuData.map((data) => (
-                <Link to={data.url}>
-                  <CommandItem key={data.url} className="flex gap-2">
+                <Link key={data.url} to={data.url}>
+                  <CommandItem
+                    className="flex cursor-pointer gap-2 "
+                    title={data.title}
+                  >
                     <Plane />
                     {data.title}
                   </CommandItem>

--- a/app/components/ui/command.tsx
+++ b/app/components/ui/command.tsx
@@ -1,0 +1,153 @@
+import * as React from "react"
+import { type DialogProps } from "@radix-ui/react-dialog"
+import { MagnifyingGlassIcon } from "@radix-ui/react-icons"
+import { Command as CommandPrimitive } from "cmdk"
+
+import { cn } from "~/lib/utils"
+import { Dialog, DialogContent } from "~/components/ui/dialog"
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+Command.displayName = CommandPrimitive.displayName
+
+interface CommandDialogProps extends DialogProps {}
+
+const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <MagnifyingGlassIcon className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  </div>
+))
+
+CommandInput.displayName = CommandPrimitive.Input.displayName
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+))
+
+CommandList.displayName = CommandPrimitive.List.displayName
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm"
+    {...props}
+  />
+))
+
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+
+CommandGroup.displayName = CommandPrimitive.Group.displayName
+
+const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 h-px bg-border", className)}
+    {...props}
+  />
+))
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  />
+))
+
+CommandItem.displayName = CommandPrimitive.Item.displayName
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+CommandShortcut.displayName = "CommandShortcut"
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
+}

--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { Cross2Icon } from "@radix-ui/react-icons"
+
+import { cn } from "~/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <Cross2Icon className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogTrigger,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -5,15 +5,16 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
-} from "@remix-run/react"
-import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs"
-import type { LinksFunction } from "@remix-run/node"
-import { menuData } from "./seed"
-import stylesheet from "~/tailwind.css?url"
+} from "@remix-run/react";
+import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
+import type { LinksFunction } from "@remix-run/node";
+import { menuData } from "./seed";
+import stylesheet from "~/tailwind.css?url";
+import { SidebarMenu } from "./components/shared/sidebar/SidebarMenu";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
-]
+];
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -24,26 +25,29 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Meta />
         <Links />
       </head>
-      <body>
-        <Tabs defaultValue="account" className="h-72 w-[full]">
-          <TabsList className=" w-full grid-cols-none">
-            {menuData.map((item) => (
-              <Link key={item.url} to={item.url}>
-                <TabsTrigger key={item.title} value={item.title}>
-                  {item.title}
-                </TabsTrigger>
-              </Link>
-            ))}
-          </TabsList>
-        </Tabs>
-        {children}
+      <body className="flex items-start justify-between">
+        <SidebarMenu></SidebarMenu>
+        <main className="h-full w-full p-5">
+          <Tabs defaultValue="account" className="h-72 w-[full]">
+            <TabsList className=" w-full grid-cols-none">
+              {menuData.map((item) => (
+                <Link key={item.url} to={item.url}>
+                  <TabsTrigger key={item.title} value={item.title}>
+                    {item.title}
+                  </TabsTrigger>
+                </Link>
+              ))}
+            </TabsList>
+          </Tabs>
+          {children}
+        </main>
         <ScrollRestoration />
         <Scripts />
       </body>
     </html>
-  )
+  );
 }
 
 export default function App() {
-  return <Outlet />
+  return <Outlet />;
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -26,7 +26,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body className="flex items-start justify-between">
-        <SidebarMenu></SidebarMenu>
+        <SidebarMenu />
         <main className="h-full w-full p-5">
           <Tabs defaultValue="account" className="h-72 w-[full]">
             <TabsList className=" w-full grid-cols-none">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@radix-ui/react-accordion": "^1.1.2",
         "@radix-ui/react-checkbox": "^1.0.4",
+        "@radix-ui/react-dialog": "^1.0.5",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-icons": "^1.3.0",
         "@radix-ui/react-slot": "^1.0.2",
@@ -19,6 +20,7 @@
         "axios": "^1.6.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "cmdk": "^1.0.0",
         "isbot": "^4.1.0",
         "lucide-react": "^0.363.0",
         "react": "^18.2.0",
@@ -1654,6 +1656,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.5.tgz",
+      "integrity": "sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "2.5.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3952,6 +3990,19 @@
       "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.0.0.tgz",
+      "integrity": "sha512-gDzVf0a09TvoJ5jnuPvygTB77+XdOSwEmJ88L6XPFPlv7T3RxbP9jgenfylrAMD0+Le1aO0nVjQUzl2g+vjz5Q==",
+      "dependencies": {
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-primitive": "1.0.3"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/color-convert": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-slot": "^1.0.2",
@@ -24,6 +25,7 @@
     "axios": "^1.6.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "cmdk": "^1.0.0",
     "isbot": "^4.1.0",
     "lucide-react": "^0.363.0",
     "react": "^18.2.0",


### PR DESCRIPTION
# Feature Sidebar Menu

## Description of Change

As we are doing this web page for challenges, we should have the sidebar menu for every detail that we are looking through the API. That is why this pull request adds a new layout with a sidebar menu component.

## Issue

We dont have a Sidebar Menu for the application

## Solution

Add the sidebar menu, with some items to play with

## Modified Files

- `app/components/shared/sidebar/SidebarHeader.tsx`
- `app/components/shared/sidebar/SidebarMenu.tsx`
- `app/components/shared/sidebar/index.ts`
- `app/root.tsx`

## Screenshots (if necessary)

![Screenshot 2024-04-02 at 10 02 15 AM](https://github.com/pandanow/challenge-page/assets/72034585/aa8c9487-49fd-46ca-bf74-cd58e63d7792)
![Screenshot 2024-04-02 at 10 02 58 AM](https://github.com/pandanow/challenge-page/assets/72034585/dfbd791c-8786-42ea-86dd-88f216684b22)


## Verification

- [x] I have tested the changes locally.
- [x] I have verified that the changes meet the requirements.
- [x] I have verified that the changes do not introduce new errors.
- [x] All tests have passed successfully.
