### PR TITLE
Added the species challenge information

### DIFF
--- a/app/data/index.ts
+++ b/app/data/index.ts
@@ -2,5 +2,6 @@ export * from "./menu-data";
 export * from "./home-data";
 export * from "./starships-challenge-data";
 export * from "./people-challenge-data";
+export * from "./species-challenge-data";
 export * from "./films-challenge-data";
 export * from "./planets-challenge-data";

--- a/app/data/species-challenge-data.tsx
+++ b/app/data/species-challenge-data.tsx
@@ -1,0 +1,30 @@
+import { Challenge, ChallengeItem } from "~/interfaces/challenge";
+
+const speciesChallengeItemsData: ChallengeItem[] = [
+  {
+    description: "Design the table component.",
+  },
+  {
+    description: "Design the row component with its functionality.",
+  },
+
+  {
+    description:
+      "Create a service that gets the information from the API endpoint. Remember to paginate the information that you receive from the API.",
+    documentationUrl: "https://swapi.dev/documentation#species",
+  },
+  {
+    description: "Call the service from server, and render the table.",
+  },
+  {
+    description:
+      "Add more stuff for it to be atractive. Let your imagination fly!",
+  },
+];
+
+export const SpeciesChallengeData: Challenge = {
+  title: "Species Challenge",
+  description:
+    "In this challenge, participants will use the Star Wars API's 'Species' endpoint to gather species details, presented in a structured table format. Using React and Remix for frontend development, contestants will create an interactive webpage where users can explore species information efficiently. A key aspect of the challenge will be implementing a paginated base table (10 items per page) with row-click functionality to display statistics and details about the selected species, along with associated characters. With Tailwind CSS for styling and ShadCN components for UI enhancements, participants will craft a visually appealing and functional webpage that offers a comprehensive view of Star Wars species data.",
+  items: speciesChallengeItemsData,
+};

--- a/app/data/species-challenge-data.tsx
+++ b/app/data/species-challenge-data.tsx
@@ -14,7 +14,8 @@ const speciesChallengeItemsData: ChallengeItem[] = [
     documentationUrl: "https://swapi.dev/documentation#species",
   },
   {
-    description: "Call the service from server, and render the table.",
+    description:
+      "Call the service from server, and render the table. Remember to use Query params for the pagination.",
   },
   {
     description:

--- a/app/routes/species.tsx
+++ b/app/routes/species.tsx
@@ -1,7 +1,32 @@
+import { Link } from "@remix-run/react";
+import { SpeciesChallengeData } from "~/data/species-challenge-data";
+
 export default function Species() {
   return (
     <div>
-      <h1 className="text-5xl font-bold">Species</h1>
+      <h1 className="mb-5 text-2xl font-bold">{SpeciesChallengeData.title}</h1>
+      <hr className="mb-10" />
+      <span className="font-light text-gray-700">
+        {SpeciesChallengeData.description}
+      </span>
+
+      <div className="mt-10 px-10 font-light text-gray-700">
+        <ul className="list-disc">
+          {SpeciesChallengeData.items.map((item, index) => (
+            <li key={index}>
+              {item.description}{" "}
+              {item.documentationUrl && (
+                <Link
+                  to={item.documentationUrl}
+                  className="text-sky-700 hover:underline"
+                >
+                  Review documentation.
+                </Link>
+              )}
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
# Added the species challenge information

## Description of Change

On this pull request we are adding the pagination challenge on species. The idea is to create a clickable row table that is being paginated on the server side.

## Issue

We needed to add a pagination base challenge, and we are using the Species module for that

## Solution

Added a new pagination module challenge using the Species api endpoint

## Modified Files

- `app/data/species-challenge-data.ts`
- `app/data/index.ts`
- `app/routes/species.tsx`

## Screenshots (if necessary)
<img width="1713" alt="Screenshot 2024-04-04 at 11 39 06 AM" src="https://github.com/pandanow/challenge-page/assets/72034585/8df7644e-a19d-45c9-9f71-04f8dd922954">
<img width="1411" alt="Screenshot 2024-04-04 at 11 39 26 AM" src="https://github.com/pandanow/challenge-page/assets/72034585/8008f92c-061d-4d8f-affa-c8d8aaa5ef76">



## Verification

- [x] I have tested the changes locally.
- [x] I have verified that the changes meet the requirements.
- [x] I have verified that the changes do not introduce new errors.
- [x] All tests have passed successfully.

